### PR TITLE
feature: Back to jfederico/scalelite-run

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,4 @@ docker_letsencrypt:
   staging: 0
 
 bbb_scalelite_env_tempalte: ".env.j2"
+bbb_scalelite_docker_recordings_mount: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,5 +29,5 @@ docker_letsencrypt:
   # 0 no staging | 1 staging
   staging: 0
 
-bbb_scalelite_env_tempalte: ".env.j2"
+bbb_scalelite_env_template: ".env.j2"
 bbb_scalelite_docker_recordings_mount: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,4 +4,4 @@
 - name: "Enable Systemd Docker Mount Restart"
   import_tasks: mount-check.yml
   when:
-    - bbb_scalelite_docker_recordings_mount is defined and bbb_scalelite_docker_recordings_mount | bool
+    - bbb_scalelite_docker_recordings_mount | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,7 @@
 ---
 - import_tasks: setup.yml
+
+- name: "Enable Systemd Docker Mount Restart"
+  import_tasks: mount-check.yml
+  when:
+    - bbb_scalelite_docker_recordings_mount is defined and bbb_scalelite_docker_recordings_mount | bool

--- a/tasks/mount-check.yml
+++ b/tasks/mount-check.yml
@@ -1,0 +1,22 @@
+- name: "Template service file"
+  ansible.builtin.template:
+    src: "docker-scalelite-recordings-mount.service.j2"
+    dest: "/etc/systemd/system/docker-scalelite-recordings-mount.service"
+    mode: '0644'
+    owner: "root"
+    group: "root"
+  register: bbb_scalelite_recordings_mount_service_file
+
+- name: "Systemd Deamon reload"
+  ansible.builtin.service:
+    daemon_reload: true
+  when:
+    - bbb_scalelite_recordings_mount_service_file.changed # noqa: no-handler
+
+- name: "Start docker scalelite recording mount service"
+  ansible.builtin.service:
+    name: "docker-scalelite-recordings-mount.service"
+    enabled: true
+    state: started
+  when:
+    - not ansible_check_mode

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -29,7 +29,7 @@
 
     - name: Create .env file
       template:
-        src: "{{ bbb_scalelite_env_tempalte }}"
+        src: "{{ bbb_scalelite_env_template }}"
         dest: /root/scalelite-run/.env
         owner: root
         group: root

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -22,9 +22,9 @@
 
     - name: Clone scalelite-run
       git:
-        repo: https://github.com/ebbba-org/scalelite-run.git
+        repo: https://github.com/jfederico/scalelite-run.git
         dest: /root/scalelite-run
-        version: v1.1
+        version: master
         force: true
 
     - name: Create .env file

--- a/templates/.env.j2
+++ b/templates/.env.j2
@@ -1,10 +1,20 @@
-### Required by scalelite-api
+### Required across containers
 SECRET_KEY_BASE={{ docker_scalelite_api['secret_key_base'] }}
+DOMAIN_NAME={{ docker_nginx['url_host']}}
+
+### Required by scalelite-api
+SL_HOST={{ docker_nginx['url_host']}}
 LOADBALANCER_SECRET={{ docker_scalelite_api['loadbalancer_secret'] }}
+# For rotating secrets, you can specify multiple secrets separated by commas. The first secret will be used for signing new tokens, but all secrets will be accepted for verifying existing tokens until they expire.
 LOADBALANCER_SECRETS={{ docker_scalelite_api['loadbalancer_secrets'] }}
+
+### Optional for scalelite-api
+# LOADBALANCER_CHECKSUM_ALGORITHM=SHA256
+
 #
 ### Required by scalelite-api and scalelite-poller
 REDIS_URL={{ docker_redis['url'] }}
+# REDIS_HOST=
 #
 ### Required by scalelite-api and scalelite-recording-importer
 DATABASE_URL={{ docker_postgres['url'] }}
@@ -13,25 +23,35 @@ SCALELITE_RECORDING_DIR={{ docker_scalelite['recording_dir'] }}
 ### Required by scalelite-nginx (only When using SSL)
 NGINX_SSL={{ docker_nginx['ssl'] | lower }}
 # SCALELITE_NGINX_EXTRA_OPTS=--mount type=bind,source=/etc/letsencrypt,target=/etc/nginx/ssl,readonly
-URL_HOST={{ docker_nginx['url_host']}}
+#
+### Required by Redis
+# DOMAIN_NAME=
 #
 ### Required when when specific repo or version (other than defaults) are needed (DEPRECATED)
-SCALELITE_REPO={{ docker_scalelite['repo'] }}
-SCALELITE_TAG={{ docker_scalelite['tag'] }}
+# SCALELITE_REPO=blindsidenetwks
+# SCALELITE_TAG=v1
 #
 ### Required when when specific repo or version (other than defaults) are needed
-SCALELITE_DOCKER_IMAGE=blindsidenetwks/scalelite:v1.0
+SCALELITE_DOCKER_IMAGE=blindsidenetwks/scalelite:v1.7
 #
 ### Required when recordings are enabled and using BigBlueButton Playback Proxy to serve the recordings.
-SCALELITE_RECORDINGS_DOCKER_IMAGE=bigbluebutton/bbb-playback-proxy:bionic-230-amazonlinux
+SCALELITE_RECORDINGS_DOCKER_IMAGE=bigbluebutton/bbb-playback-proxy:jammy-300-alpine
+#
+### Optional for nginx when using docker-compose
+# NGINX_DOCKER_IMAGE=
+# CERTBOT_DOCKER_IMAGE=
 #
 ### Optional for postgres when using docker-compose
 POSTGRES_USER={{ docker_postgres['user'] }}
 POSTGRES_PASSWORD={{ docker_postgres['password'] }}
+# POSTGRES_DOCKER_IMAGE=
+#
+### Optional for redis when using docker-compose
+# REDIS_DOCKER_IMAGE=
 #
 ### Optional for init-letsencrypt.sh when using certbot for generating signed SSL certificates
-LETSENCRYPT_EMAIL={{ docker_letsencrypt['email'] }}
-LETSENCRYPT_STAGING={{ docker_letsencrypt['staging'] }} # Set to 1 if you're testing your setup to avoid hitting request limits
+#LETSENCRYPT_EMAIL=
+#LETSENCRYPT_STAGING=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 #
 ### Optional since v1.0.12
 # DB_DISABLED=false
@@ -41,14 +61,115 @@ LETSENCRYPT_STAGING={{ docker_letsencrypt['staging'] }} # Set to 1 if you're tes
 # RECORDING_IMPORT_POLL_INTERVAL=60
 # RECORDING_IMPORT_UNPUBLISHED=false
 #
-### Optional when using docker-compose-dev.yml
-# DOCKER_VOL_SCALELITE_API=~/scalelite-run/data/scalelite
-# DOCKER_VOL_POSTGRES_DATA=~/scalelite-run/data/postgres
-# DOCKER_VOL_REDIS_DATA=~/scalelite-run/data/redis
+### Optional for persistent data storage with docker-compose
+### Defaults to {PWD}/data/postgres/db and {PWD}/data/redis/db if not specified
+### Note: Docker requires ABSOLUTE paths for bind mounts. Use full paths or leave blank for defaults.
+# DOCKER_VOL_POSTGRES_DATA=/home/ubuntu/xdev/scalelite-run/data/postgres/db
+# DOCKER_VOL_REDIS_DATA=/home/ubuntu/xdev/scalelite-run/data/redis/db
 #
 ### Optional for development when using different profiles
 DOCKER_PROXY_NGINX_TEMPLATE=scalelite-proxy
-#DOCKER_PROXY_NGINX_TEMPLATE=scalelite-local
-#DOCKER_PROXY_NGINX_TEMPLATE=scalelite-cluster
+# Examples:
+#   scalelite-proxy <default>
+#   scalelite-proxy-protected
+#   scalelite-local
+#   scalelite-local-protected
+#   scalelite-cluster
+#
+### Optional for the deployment, but required when using init-letsencrypt.sh script
+# LETSENCRYPT_EMAIL=
+# LETSENCRYPT_STAGING=0
+#   Set to 1 if you're testing your setup to avoid hitting request limits
 
-SERVER_ID_IS_HOSTNAME={{ docker_scalelite_api['server_id_is_hostname'] }}
+### Optional for Multitenancy
+# MULTITENANCY_ENABLED=
+# You can use this image to automate the DNS challenge if you are using the AWS suite
+# CERTBOT_DOCKER_IMAGE=certbot/dns-route53
+#
+### Additional optional configuration for scalelite-api
+### DNS/Security
+# URL_HOST=
+# Sets the hostname that the application API endpoint is accessible from. Used to protect against DNS rebinding attacks.
+# Also used to construct the analytics callback URL (meta_analytics-callback-url) that is sent to BigBlueButton servers.
+# Should include the domain and subdomain (e.g., sl.example.com). Leave blank if behind a Network Load Balancer or when using
+# docker compose.
+# ANALYTICS_CALLBACK_URL_HOST=
+# For HA deployments behind proxy/load balancer: set this to the public-facing hostname if URL_HOST is set to an internal hostname.
+# If not set, falls back to URL_HOST. Example: URL_HOST=scalelite-api (internal), ANALYTICS_CALLBACK_URL_HOST=sl.example.com (public)
+# NGINX_BEHIND_PROXY=false
+# NGINX_RECORDINGS_ONLY=false
+#
+### Rails/Server configuration
+# PORT=3000
+# BIND=
+# INTERVAL=60
+# WEB_CONCURRENCY=2
+# RAILS_MAX_THREADS=3
+# RAILS_ENV=production
+# BUILD_NUMBER=
+# RAILS_LOG_TO_STDOUT=true
+# RAILS_LOG_LEVEL=debug
+#
+### Redis configuration
+# REDIS_POOL=3
+#
+### Meeting configuration
+# MAX_MEETING_DURATION=0
+# DEFAULT_MEETING_TTL=
+#
+### Recording directories
+# RECORDING_SPOOL_DIR=/var/bigbluebutton/spool
+# RECORDING_WORK_DIR=/var/bigbluebutton/recording/scalelite
+# RECORDING_PUBLISH_DIR=/var/bigbluebutton/published
+# RECORDING_UNPUBLISH_DIR=/var/bigbluebutton/unpublished
+# RECORDING_PLAYBACK_FORMATS=presentation:video:podcast:notes:capture
+#
+### Health check thresholds
+# SERVER_HEALTHY_THRESHOLD=1
+# SERVER_UNHEALTHY_THRESHOLD=2
+#
+### API configuration
+# GET_MEETINGS_API_DISABLED=false
+# GET_RECORDINGS_API_FILTERED=false
+#
+### Polling configuration
+# POLLER_THREADS=5
+# CONNECT_TIMEOUT=5
+# POLLER_WAIT_TIMEOUT=10
+# RESPONSE_TIMEOUT=10
+#
+### Load balancing
+# LOAD_MIN_USER_COUNT=15
+# LOAD_JOIN_BUFFER_TIME=15
+# SERVER_ID_IS_HOSTNAME=false
+#
+### API parameter filtering
+# CREATE_EXCLUDE_PARAMS=
+# JOIN_EXCLUDE_PARAMS=
+# DEFAULT_CREATE_PARAMS=
+# OVERRIDE_CREATE_PARAMS=
+# DEFAULT_JOIN_PARAMS=
+# OVERRIDE_JOIN_PARAMS=
+#
+### Database configuration
+# PREPARED_STATEMENT=true
+# DB_CONNECTION_RETRY_COUNT=3
+#
+### Protected Recordings feature (Requires SCALELITE_TAG >= v1.2)
+# PROTECTED_RECORDINGS_ENABLED=false
+# PROTECTED_RECORDINGS_TOKEN_TIMEOUT=60
+# PROTECTED_RECORDINGS_TIMEOUT=360
+#
+### API port configuration
+# SCALELITE_API_PORT=3000
+#
+### Localization
+# DEFAULT_LOCALE=en
+#
+### Voice bridge configuration
+# VOICE_BRIDGE_LEN=7
+# VOICE_BRIDGE_MIN=5
+# VOICE_BRIDGE_MAX=9
+# USE_EXTERNAL_VOICE_BRIDGE=false
+# FSAPI_PASSWORD=
+# FSAPI_MAX_DURATION=

--- a/templates/.env.j2
+++ b/templates/.env.j2
@@ -1,9 +1,9 @@
 ### Required across containers
 SECRET_KEY_BASE={{ docker_scalelite_api['secret_key_base'] }}
-DOMAIN_NAME={{ docker_nginx['url_host']}}
+DOMAIN_NAME={{ bbb_scalelite_domain_name }}
 
 ### Required by scalelite-api
-SL_HOST={{ docker_nginx['url_host']}}
+SL_HOST={{ bbb_scalelite_domain_sub_name }}
 LOADBALANCER_SECRET={{ docker_scalelite_api['loadbalancer_secret'] }}
 # For rotating secrets, you can specify multiple secrets separated by commas. The first secret will be used for signing new tokens, but all secrets will be accepted for verifying existing tokens until they expire.
 LOADBALANCER_SECRETS={{ docker_scalelite_api['loadbalancer_secrets'] }}

--- a/templates/docker-scalelite-recordings-mount.service.j2
+++ b/templates/docker-scalelite-recordings-mount.service.j2
@@ -2,8 +2,8 @@
 Description="Restart Scalelite Recordings Container"
 ConditionPathIsReadWrite={{ bbb_scalelite_recordings_path }}
 After=network.target
-{% if bbb_scalelite_recording_systemd_mount %}After={{ bbb_scalelite_recording_systemd_mount }}
-BindsTo={{ bbb_scalelite_recording_systemd_mount }}{% endif %}
+{% if bbb_scalelite_docker_recordings_systemd %}After={{ bbb_scalelite_docker_recordings_systemd }}
+BindsTo={{ bbb_scalelite_docker_recordings_systemd }}{% endif %}
 
 [Service]
 Type=oneshot

--- a/templates/docker-scalelite-recordings-mount.service.j2
+++ b/templates/docker-scalelite-recordings-mount.service.j2
@@ -1,7 +1,9 @@
 [Unit]
-Description="Restart Recordings Container Once If Path Exist"
+Description="Restart Scalelite Recordings Container"
 ConditionPathIsReadWrite={{ bbb_scalelite_recordings_path }}
 After=network.target
+{% if bbb_scalelite_recording_systemd_mount %}After={{ bbb_scalelite_recording_systemd_mount }}
+BindsTo={{ bbb_scalelite_recording_systemd_mount }}{% endif %}
 
 [Service]
 Type=oneshot
@@ -10,3 +12,6 @@ Restart=on-failure
 RestartSec=60s
 RestartSteps=4
 RestartMaxDelaySec=360s
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/docker-scalelite-recordings-mount.service.j2
+++ b/templates/docker-scalelite-recordings-mount.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description="Restart Recordings Container Once If Path Exist"
+ConditionPathIsReadWrite={{ bbb_scalelite_recordings_path }}
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker restart scalelite-recordings
+Restart=on-failure
+RestartSec=60s
+RestartSteps=4
+RestartMaxDelaySec=360s


### PR DESCRIPTION
## Reason

The current [ebbba/scalelite-run](https://github.com/ebbba-org/scalelite-run) is not up to date. It used older version of Redis and Postgres and the development is fallen asleep.

## New feature

Recordings can be stored on a disk that are encrypted and managed by Systemd. The recordings Docker container should restart the service restarts.